### PR TITLE
Added support for IMMO box 1, IMMO box 2

### DIFF
--- a/BlockTitle.cs
+++ b/BlockTitle.cs
@@ -25,6 +25,7 @@
         AdaptationSave = 0x2A,
         Login = 0x2B,
         SecurityAccessMode2 = 0x3D,
+        SecurityImmoAccess1 = 0x5C,
         SecurityAccessMode1 = 0xD7,
         AdaptationResponse = 0xE6,
         GroupReadResponse = 0xE7,

--- a/KW1281Dialog.cs
+++ b/KW1281Dialog.cs
@@ -80,6 +80,8 @@ namespace BitFab.KW1281Test
 
         bool GroupRead(byte groupNumber, bool useBasicSetting = false);
 
+        List<byte> ReadSecureImmoAccess(List<byte> blockBytes);
+
         public IKwpCommon KwpCommon { get; }
         Block ReceiveBlock();
     }
@@ -829,6 +831,29 @@ namespace BitFab.KW1281Test
             Log.WriteLine(LogDest.Console);
 
             return true;
+        }
+
+        public List<byte> ReadSecureImmoAccess(List<byte> blockBytes)
+        {
+
+            blockBytes.Insert(0, (byte)BlockTitle.SecurityImmoAccess1);
+
+            Log.WriteLine($"Sending ReadSecureImmoAccess block: {Utils.DumpBytes(blockBytes)}");
+
+            SendBlock(blockBytes);
+            var blocks = ReceiveBlocks();
+
+            if (blocks.Count == 1 && blocks[0] is NakBlock)
+            {
+                return new List<byte>();
+            }
+
+            blocks = blocks.Where(b => !b.IsAckNak).ToList();
+            if (blocks.Count != 1)
+            {
+                throw new InvalidOperationException($"ReadRomEeprom returned {blocks.Count} blocks instead of 1");
+            }
+            return blocks[0].Body.ToList();
         }
 
         /// <summary>

--- a/Tester.cs
+++ b/Tester.cs
@@ -644,6 +644,28 @@ namespace BitFab.KW1281Test
                     var skc = Utils.GetBcd(buf, 0x08);
                     Log.WriteLine($"SKC: {skc:D5}");
                 }
+                else if (ecuInfo.Text.Contains("VWZ3Z0"))
+                {
+                    // IMMO BOX 1 1H0 953 257 and 7M0 953 257 support
+                    // Tried to shorten count but IMMO responds only with code 0x50 or higher
+                    var blockBytes = _kwp1281.ReadRomEeprom(0x0190, 176);
+                    if (blockBytes == null)
+                    {
+                        Log.WriteLine("ROM read failed");
+                    }
+                    else
+                    {
+                        if (blockBytes.Count == 0)
+                        {
+                            Log.WriteLine("Failed to read SKC. Immo appers to be locked. You have to use adapted key.");
+                            return;
+                        }
+
+                        var skc = Utils.GetShortBE(blockBytes.ToArray(), 1);
+
+                        Log.WriteLine($"SKC: {skc:D5}");
+                    }
+                }
                 else if (ecuInfo.Text.Contains("AGD"))
                 {
                     Log.WriteLine($"Unsupported Magneti Marelli AGD cluster: {ecuInfo.Text}");

--- a/Tester.cs
+++ b/Tester.cs
@@ -647,24 +647,51 @@ namespace BitFab.KW1281Test
                 else if (ecuInfo.Text.Contains("VWZ3Z0"))
                 {
                     // IMMO BOX 1 1H0 953 257 and 7M0 953 257 support
-                    // Tried to shorten count but IMMO responds only with code 0x50 or higher
+                    // Based on sniffed Vag tacho communication
+                    // 7M0 953 257 can be both IMMO BOX 1 or IMMO BOX 2
+
                     var blockBytes = _kwp1281.ReadRomEeprom(0x0190, 176);
-                    if (blockBytes == null)
+                    if (blockBytes == null || blockBytes.Count == 0)
                     {
-                        Log.WriteLine("ROM read failed");
-                    }
-                    else
-                    {
-                        if (blockBytes.Count == 0)
+                        if (blockBytes == null)
                         {
-                            Log.WriteLine("Failed to read SKC. Immo appers to be locked. You have to use adapted key.");
+                            Log.WriteLine("ROM read failed");
                             return;
                         }
 
-                        var skc = Utils.GetShortBE(blockBytes.ToArray(), 1);
+                        if (ecuInfo.Text.Contains("1H0"))
+                        {
+                            Log.WriteLine("Failed to read SKC. Immo appears to be locked. You have to use an adapted key.");
+                            return;
+                        }
 
-                        Log.WriteLine($"SKC: {skc:D5}");
+                        if (ecuInfo.Text.Contains("6H0") || ecuInfo.Text.Contains("7M0"))
+                        {
+                            // This part adds IMMO BOX 2 experimental support (could not test this with real box).
+                            // Should work for 6H0 953 257 and 7M0 953 257
+
+                            Log.WriteLine("Trying to unlock IMMO BOX 2. This function is experimental and may not work...");
+
+                            // Unlock ROM
+                            _kwp1281.SendBlock(new List<byte> { 0xCB, 0x5D, 0x3B, 0xD3, 0x8A });
+
+                            // Send custom read command
+                            blockBytes = _kwp1281.ReadSecureImmoAccess(new List<byte> { 0x02, 0x00, 0x65, 0x34, 0x9D });
+
+                            if (blockBytes == null || blockBytes.Count == 0)
+                            {
+                                Log.WriteLine("Failed to read SKC. Immo appears to be locked. You have to use an adapted key.");
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            return;
+                        }
                     }
+
+                    var skc = Utils.GetShortBE(blockBytes.ToArray(), 1);
+                    Log.WriteLine($"SKC: {skc:D5}");
                 }
                 else if (ecuInfo.Text.Contains("AGD"))
                 {


### PR DESCRIPTION
Added IMMO BOX 1 1H0 953 257 support. Adapted key is needed to unlock ROM reading.

Experimental IMMO BOX 2 support 6H0 953 257

7M0 953 257 can be both IMMO BOX 1 or IMMO BOX 2